### PR TITLE
Fixing Calling multiple async calls crashing bug

### DIFF
--- a/android/src/main/java/io/paratoner/flutter_tesseract_ocr/FlutterTesseractOcrPlugin.java
+++ b/android/src/main/java/io/paratoner/flutter_tesseract_ocr/FlutterTesseractOcrPlugin.java
@@ -72,8 +72,7 @@ public class FlutterTesseractOcrPlugin implements FlutterPlugin, MethodCallHandl
               final File tempFile = new File(imagePath);
               baseApi.setPageSegMode(DEFAULT_PAGE_SEG_MODE);
       
-              Thread t = new Thread(new MyRunnable(baseApi, tempFile, recognizedText, result, call.method.equals("extractHocr")));
-              t.start();
+              new MyRunnable(baseApi, tempFile, recognizedText, result, call.method.equals("extractHocr")).run();
               break; 
       
             default:


### PR DESCRIPTION
When you try to call another `.extractText` without waiting for the first one to finish. The app will crash and give you an address error. The invoke method is async in Flutter, why should it be async too in Java too? (`new Thread()`)
Without making a new Thread, I'm able to call `.extractText` multiple times.